### PR TITLE
Improve build

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -2,5 +2,5 @@ FROM golang:1.10
 
 RUN apt update -y && \
       apt install -y mysql-client mysql-server
-RUN curl https://glide.sh/get | sh && \
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh && \
       go get -u golang.org/x/lint/golint

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -58,10 +58,6 @@
   version = "0.2.0"
 
 [[constraint]]
-  name = "github.com/pkg/errors"
-  version = "0.8.0"
-
-[[constraint]]
   name = "github.com/satori/go.uuid"
   version = "1.2.0"
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ deps:
 	@dep ensure
 
 build: deps
-	@go build 
+	@go build
 
 test: gotest golint govet
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,6 @@
 SHELL := /bin/bash
 
-dep:
-ifeq ($(shell which dep 2>/dev/null),)
-	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-endif
-
-deps: dep
+deps:
 	@dep ensure
 
 build: deps
@@ -30,4 +25,4 @@ coverage:
 migrate:
 	@mysql -h $(REPOSITORY_MYSQL_ADDRESS) -u $(REPOSITORY_MYSQL_USER) < database/schema.sql
 
-.PHONY: dep deps build test gotest golint govet coverage
+.PHONY: deps build test gotest golint govet coverage


### PR DESCRIPTION
This makes better installing dep on CI.

- Install dep on not CircleCI building but Docker image building.
- Remove glide perfectly.

These speed up building process in CircleCI(and local building by `circleci` command, of course).

Other nit fixes:
- Remove trailing space in Makefile.
- Remove unused dependency in Gopkg.toml.

Thanks!